### PR TITLE
This fixes a bug where  grumble/bubble does not work if you include it in the head of your page instead of at the very bottom

### DIFF
--- a/js/Bubble.js
+++ b/js/Bubble.js
@@ -13,12 +13,13 @@
         distance: 50,
         template: '<div class="grumble" style="display:none;filter:progid:DXImageTransform.Microsoft.Matrix(sizingMethod=\'auto expand\')">&#160;</div>',
         textTemplate: '<div class="grumble-text" style="display:none;"><div class="outer"><div class="inner">{text}</div></div></div>',
-        context: $('body')
+        context: null
     };
 
     window.GrumbleBubble = function(options){
+    	
         this.options = $.extend({},defaults,options);
-        this.context = $(this.options.context); 
+        this.context = $(this.options.context || $('body')); 
         this.css = {};
         this.create();
     };


### PR DESCRIPTION
If you happen to include Bubble.js in the <head> of your DOM, then the $('body') selector may not select an element as it has not been parsed yet. This fixed that bug.
